### PR TITLE
Fix: Update InstrumentationRegistry call for Android

### DIFF
--- a/android/src/androidTest/java/com/getcapacitor/android/ExampleInstrumentedTest.java
+++ b/android/src/androidTest/java/com/getcapacitor/android/ExampleInstrumentedTest.java
@@ -20,7 +20,7 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() throws Exception {
         // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
         assertEquals("com.getcapacitor.android", appContext.getPackageName());
     }


### PR DESCRIPTION
This PR updates the InstrumentationRegistry call in `ExampleInstrumentedTest.java` for compatibility for Android API level 28 and above, as the previous `getTargetContext()` call was deprecated in API 28.

See issue: https://github.com/calvinckho/capacitor-share-extension/issues/13