### PR TITLE
Fix type definitions of checkSendIntentReceived() and finish()

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,6 +1,6 @@
 export interface ShareExtensionPlugin {
-    checkSendIntentReceived(): Promise<Intent>;
-    finish(): void;
+    checkSendIntentReceived(): Promise<{ payload: Intent[] }>;
+    finish(): Promise<{ success: boolean }>;
     saveDataToKeychain(options: { key: string, data: any }): Promise<string>;
     clearKeychainData(options: { key: string }): Promise<any>;
 }
@@ -11,5 +11,4 @@ export interface Intent {
     type?: string;
     url?: string;
     webPath?: string;
-    additionalItems?: any;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,29 +2,22 @@ import { WebPlugin } from '@capacitor/core';
 import { ShareExtensionPlugin } from './definitions';
 
 export class ShareExtensionWeb extends WebPlugin implements ShareExtensionPlugin {
-  constructor() {
-    super({
-      name: 'ShareExtension',
-      platforms: ['web']
-    });
+  async checkSendIntentReceived(): ReturnType<ShareExtensionPlugin["checkSendIntentReceived"]> {
+    return { payload: [] };
   }
 
-  async checkSendIntentReceived(): Promise<{ title: string }> {
-    return {title: null};
+  async clearKeychainData(): ReturnType<ShareExtensionPlugin["clearKeychainData"]> {
+    return undefined;
   }
 
-  finish(): void {
+  async finish(): ReturnType<ShareExtensionPlugin["finish"]> {
+    return { success: true };
   }
 
-  async saveDataToKeychain(options: { key: string, data: any }): Promise<string> {
-    console.log('save', options);
-    return 'not implemented yet for web';
+  async saveDataToKeychain(): ReturnType<ShareExtensionPlugin["saveDataToKeychain"]> {
+    return "";
   }
 
-  async clearKeychainData(options: { key: string }): Promise<any> {
-    console.log('clear completed', options);
-    return
-  }
 }
 
 const ShareExtension = new ShareExtensionWeb();


### PR DESCRIPTION
This pull request fixes the type definitions of the plugin, to reflect the actual return type of `checkSendIntentReceived()` and `finish()`. It also updates the web implementation to adhere to the defined structure.